### PR TITLE
Fix: prevent editing extension title

### DIFF
--- a/.pi/extensions/example.ts
+++ b/.pi/extensions/example.ts
@@ -1,0 +1,34 @@
+import { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { SettingDefinition } from "../../src";
+import { getSetting, setSetting } from "../../src";
+
+const ExampleExtension: ExtensionFactory = (pi) => {
+  /**
+   * Simple example that registers settings and reads one of them.
+   */
+  pi.events.emit("pi-extension-settings:register", {
+    name: "example-extension",
+    settings: [
+      {
+        id: "theme",
+        label: "Theme",
+        description: "Preferred UI theme",
+        defaultValue: "light",
+        values: ["light", "dark"],
+      },
+      {
+        id: "username",
+        label: "Username",
+        description: "Name shown in logs",
+        defaultValue: "",
+      },
+    ] satisfies SettingDefinition[],
+  });
+
+  const theme = getSetting("example-extension", "theme", "light");
+  if (theme === "dark") {
+    setSetting("example-extension", "username", "dark-mode-user");
+  }
+};
+
+export default ExampleExtension;

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,3 @@
+{
+  "extensions": ["../src/index.ts"]
+}

--- a/src/components/settings-list.ts
+++ b/src/components/settings-list.ts
@@ -30,6 +30,8 @@ export interface SettingItem {
 	values?: string[];
 	/** If provided, Enter opens this submenu. Receives current value and done callback. */
 	submenu?: (currentValue: string, done: (selectedValue?: string) => void) => Component;
+	/** If false, item is selectable but cannot be edited or changed. */
+	editable?: boolean;
 }
 
 export interface SettingsListTheme {
@@ -269,6 +271,10 @@ export class SettingsList implements Component {
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
 		const item = displayItems[this.selectedIndex];
 		if (!item) return;
+
+		if (item.editable === false) {
+			return;
+		}
 
 		if (item.submenu) {
 			// Open submenu, passing current value so it can pre-select correctly

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,7 @@ export default function piLibExtension(pi: ExtensionAPI) {
 						label: theme.bold(extName),
 						currentValue: "",
 						values: undefined, // No cycling - acts as header
+						editable: false,
 					});
 
 					// Add each setting


### PR DESCRIPTION
## Summary
When editing extension settings, the extension title becomes editable.

## Steps to Reproduce
1. Open extension settings.
2. Enter edit mode for a setting.
3. Observe the extension title field is editable.

## Expected Behavior
Extension title should remain read-only while editing settings.

## Actual Behavior
Extension title becomes editable.

## Additional Context
Please lock the title field during settings edits.

## Issues
- Fixes #1