### PR TITLE
Localize settings empty-state copy

### DIFF
--- a/src/components/settings-list.ts
+++ b/src/components/settings-list.ts
@@ -13,6 +13,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@mariozechner/pi-tui";
+import { t } from "../i18n.js";
 
 export interface SettingItem {
 	/** Unique identifier for this setting */
@@ -115,7 +116,7 @@ export class SettingsList implements Component {
 		}
 
 		if (this.items.length === 0) {
-			lines.push(this.theme.hint("  No settings available"));
+			lines.push(this.theme.hint(`  ${t("settings.noneAvailable", "No settings available")}`));
 			if (this.searchEnabled) {
 				this.addHintLine(lines);
 			}
@@ -124,7 +125,7 @@ export class SettingsList implements Component {
 
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
 		if (displayItems.length === 0) {
-			lines.push(this.theme.hint("  No matching settings"));
+			lines.push(this.theme.hint(`  ${t("settings.noneMatching", "No matching settings")}`));
 			this.addHintLine(lines);
 			return lines;
 		}
@@ -318,11 +319,13 @@ export class SettingsList implements Component {
 	private addHintLine(lines: string[]): void {
 		lines.push("");
 		if (this.editingInput) {
-			lines.push(this.theme.hint("  Enter to confirm · Esc to cancel"));
+			lines.push(this.theme.hint(`  ${t("settings.hint.editing", "Enter to confirm · Esc to cancel")}`));
 		} else if (this.searchEnabled) {
-			lines.push(this.theme.hint("  Type to search · Enter/Space to change · Esc to cancel"));
+			lines.push(
+				this.theme.hint(`  ${t("settings.hint.search", "Type to search · Enter/Space to change · Esc to cancel")}`),
+			);
 		} else {
-			lines.push(this.theme.hint("  Enter/Space to change · Esc to cancel"));
+			lines.push(this.theme.hint(`  ${t("settings.hint.default", "Enter/Space to change · Esc to cancel")}`));
 		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { getSettingsListTheme } from "@mariozechner/pi-coding-agent";
 import { Container, Text } from "@mariozechner/pi-tui";
 import { OrderedMultiSelect } from "./components/ordered-multi-select.js";
 import { type SettingItem, SettingsList } from "./components/settings-list.js";
+import { initI18n, t } from "./i18n.js";
 import { getSetting, setSetting } from "./settings/storage.js";
 import type { SettingDefinition } from "./settings/types.js";
 
@@ -16,6 +17,8 @@ interface RegistrationPayload {
 }
 
 export default function piLibExtension(pi: ExtensionAPI) {
+	initI18n(pi);
+
 	// Local registry - stores settings registered via events
 	const registry = new Map<string, SettingDefinition[]>();
 
@@ -30,7 +33,10 @@ export default function piLibExtension(pi: ExtensionAPI) {
 		handler: async (_args, ctx) => {
 			if (registry.size === 0) {
 				ctx.ui.notify(
-					"No extensions have registered settings. Ensure pi-extension-settings is listed before consumer extensions in your packages array in ~/.pi/settings.json.",
+					t(
+						"settings.noneRegistered",
+						"No extensions have registered settings. Ensure pi-extension-settings is listed before consumer extensions in your packages array in ~/.pi/settings.json.",
+					),
 					"info",
 				);
 				return;
@@ -43,7 +49,7 @@ export default function piLibExtension(pi: ExtensionAPI) {
 				const container = new Container();
 
 				// Title
-				container.addChild(new Text(theme.fg("accent", theme.bold("Extension Settings")), 1, 1));
+				container.addChild(new Text(theme.fg("accent", theme.bold(t("settings.title", "Extension Settings"))), 1, 1));
 
 				// Build items grouped by extension
 				const items: SettingItem[] = [];

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,63 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"settings.noneRegistered": "Ninguna extensión ha registrado ajustes. Asegúrate de que pi-extension-settings aparezca antes que las extensiones consumidoras en el array packages de ~/.pi/settings.json.",
+		"settings.title": "Ajustes de extensiones",
+		"settings.noneAvailable": "No hay ajustes disponibles",
+		"settings.noneMatching": "No hay ajustes coincidentes",
+		"settings.hint.editing": "Enter para confirmar · Esc para cancelar",
+		"settings.hint.search": "Escribe para buscar · Enter/Space para cambiar · Esc para cancelar",
+		"settings.hint.default": "Enter/Space para cambiar · Esc para cancelar",
+	},
+	fr: {
+		"settings.noneRegistered": "Aucune extension n’a enregistré de paramètres. Assurez-vous que pi-extension-settings apparaît avant les extensions consommatrices dans le tableau packages de ~/.pi/settings.json.",
+		"settings.title": "Paramètres des extensions",
+		"settings.noneAvailable": "Aucun paramètre disponible",
+		"settings.noneMatching": "Aucun paramètre correspondant",
+		"settings.hint.editing": "Entrée pour confirmer · Échap pour annuler",
+		"settings.hint.search": "Tapez pour rechercher · Entrée/Espace pour modifier · Échap pour annuler",
+		"settings.hint.default": "Entrée/Espace pour modifier · Échap pour annuler",
+	},
+	"pt-BR": {
+		"settings.noneRegistered": "Nenhuma extensão registrou configurações. Verifique se pi-extension-settings aparece antes das extensões consumidoras no array packages em ~/.pi/settings.json.",
+		"settings.title": "Configurações de extensões",
+		"settings.noneAvailable": "Nenhuma configuração disponível",
+		"settings.noneMatching": "Nenhuma configuração correspondente",
+		"settings.hint.editing": "Enter para confirmar · Esc para cancelar",
+		"settings.hint.search": "Digite para buscar · Enter/Space para alterar · Esc para cancelar",
+		"settings.hint.default": "Enter/Space para alterar · Esc para cancelar",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: ExtensionAPI): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "pi-extension-settings",
+		defaultLocale: "en",
+		locales: translations,
+	});
+
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const next = api.getLocale?.();
+			if (isLocale(next)) currentLocale = next;
+			api.onLocaleChange?.((locale) => {
+				if (isLocale(locale)) currentLocale = locale;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}


### PR DESCRIPTION
`/extension-settings` is a configuration surface for other extensions, so the high-risk copy is the text that tells users whether settings are available, how to search/change/cancel, and why nothing appeared.

This PR localizes only that settings-navigation/empty-state path and leaves extension-provided setting labels/descriptions untouched.

What changed:
- added a tiny optional i18n bridge in `src/i18n.ts`
- registered `es`, `fr`, and `pt-BR` strings
- wrapped only: no-registered-settings message, title, empty/filter-empty states, and keyboard hints

What did not change:
- no required dependency
- no behavior change without a Pi i18n provider
- English fallback strings stay in the call sites
- no README, package metadata, storage behavior, or extension-provided labels changed
- easy to revert by deleting `src/i18n.ts` and the small wrappers

Validation:
- `npm run build` passed
- `npm pack --dry-run` passed
- `npm test` is blocked because the repo currently has no `test/*.test.ts` files for the configured script

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.
